### PR TITLE
process the scanf() output so Ubuntu 22 compiler doesn't error due to…

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -1035,7 +1035,7 @@ int main(int argc, char ** argv) {
                     if(params.use_color) printf(ANSI_BOLD ANSI_COLOR_GREEN);
                     if (scanf("%255[^\n]%n%*c", buf, &n_read) <= 0) {
                         // presumable empty line, consume the newline
-                        scanf("%*c");
+                        if (scanf("%*c") <= 0) { /*ignore*/ }
                         n_read=0;
                     }
                     if(params.use_color) printf(ANSI_COLOR_RESET);


### PR DESCRIPTION
… default warn_unused_result instead of Makefile -Wunused-result

Ubuntu 22.04.2 LTS gcc version 11.3.0 (Ubuntu 11.3.0-1ubuntu1~22.04)  errors during compilation because of an unused result. fixed (checks for value, but ignores which the parent check ALSO does).