### PR TITLE
add easy Windows install instructions to the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,22 @@ build-sanitize-addr/
 build-sanitize-thread/
 
 models/*
+*.bin
 
 /main
 /quantize
 
 arm_neon.h
 compile_commands.json
+
+# Windows CMake files
+*.vcxproj
+*.filters
+*.cmake
+*.sln
+x64/
+Debug/
+Release/
+CMakeFiles/
+CMakeCache.txt
+*.dir/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This combines the [LLaMA foundation model](https://github.com/facebookresearch/l
 
 ## Get started
 
-```
+```sh
 git clone https://github.com/antimatter15/alpaca.cpp
 cd alpaca.cpp
 
@@ -33,6 +33,27 @@ wget -O ggml-alpaca-7b-q4.bin -c https://cloudflare-ipfs.com/ipfs/QmQ1bf2BTnYxq7
 Save the `ggml-alpaca-7b-q4.bin` file in the same directory as your `./chat` executable. 
 
 The weights are based on the published fine-tunes from `alpaca-lora`, converted back into a pytorch checkpoint with a [modified script](https://github.com/tloen/alpaca-lora/pull/19) and then quantized with llama.cpp the regular way. 
+
+## Windows Setup
+
+- Download and install CMake: <https://cmake.org/download/>
+- Download and install `git`. If you've never used git before, consider a GUI client like <https://desktop.github.com/>
+- Clone this repo using your git client of choice (for GitHub Desktop, go to File -> Clone repository -> From URL and paste `https://github.com/antimatter15/alpaca.cpp` in as the URL)
+- Open a Windows Terminal inside the folder you cloned the repository to
+- Run the following commands one by one:
+
+```ps1
+cmake .
+cmake --build . --config Release
+```
+
+- Download the weights via any of the links in "Get started" above, and save the file as `ggml-alpaca-7b-q4.bin` in the main Alpaca directory.
+- In the terminal window, run this command:
+```ps1
+.\Release\chat.exe
+```
+- (You can add other launch options like `--n 8` as preferred onto the same line)
+- You can now type to the AI in the terminal and it will reply. Enjoy!
 
 ## Credit
 

--- a/chat.cpp
+++ b/chat.cpp
@@ -915,7 +915,7 @@ int main(int argc, char ** argv) {
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
                " - Press Ctrl+C to interject at any time.\n"
 #endif
-               " - Press Return to return control to LLaMa.\n"
+               " - Press Return to return control to LLaMA.\n"
                " - If you want to submit another line, end your input in '\\'.\n");
     }
 


### PR DESCRIPTION
This adds extremely simple user-friendly install instructions for Windows users, to hopefully make it much easier for the average (non-technical) user to give Alpaca.cpp a try.

I tested these install instructions myself, and had another user try them as well, we both got it running with no issue based on this.

This PR also adds to the `.gitignore` all files that Windows CMake tends to generate.

In this PR I also fixed a tiny typo I noticed, it should be  `LLaMA` not `LLaMa` (the caps).

You can view the formatted markdown @ <https://github.com/mcmonkey4eva/alpaca.cpp/blob/master/README.md> if you'd like to double-check it.