### PR TITLE
Windows console ANSI color issue fixed

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #elif defined (_WIN32)
 #include <signal.h>
+#include <Windows.h>
 #endif
 
 #define ANSI_COLOR_RED     "\x1b[31m"
@@ -886,6 +887,11 @@ int main(int argc, char ** argv) {
         sigaction(SIGINT, &sigint_action, NULL);
 #elif defined (_WIN32)
         signal(SIGINT, sigint_handler);
+		//Windows console ANSI color fix 
+		HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+		DWORD mode;
+		GetConsoleMode(hConsole, &mode);
+		SetConsoleMode(hConsole, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 #endif
 
         fprintf(stderr, "%s: interactive mode on.\n", __func__);


### PR DESCRIPTION
This is quick fix for windows console color issue
![windows-console-color](https://user-images.githubusercontent.com/3255994/226101843-638ab9ce-8e98-4621-9076-b04793affa72.PNG)

Fixed output
![color-fixed](https://user-images.githubusercontent.com/3255994/226101882-556820fc-7148-4240-bbf4-43803b28d129.PNG)
