### PR TITLE
📝 Add filenames to IPFS hashes, add IPFS hash to 13b model

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Torrent: `magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-a
 
 ```sh
 # any of these will work
-wget -c https://gateway.estuary.tech/gw/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
-wget -c https://ipfs.io/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
-wget -c https://cloudflare-ipfs.com/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+curl -o ggml-alpaca-13b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+curl -o ggml-alpaca-13b-q4.bin -C - https://ipfs.io/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+curl -o ggml-alpaca-13b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
 ipfs get QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ TODO: write more docs here (PRs welcome)
 
 Torrent: `magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-alpaca-13b-q4.bin&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fopentracker.i2p.rocks%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2810%2Fannounce`
 
+```sh
+# any of these will work
+wget -c https://gateway.estuary.tech/gw/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+wget -c https://ipfs.io/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+wget -c https://cloudflare-ipfs.com/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+ipfs get QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+```
 
 ```
 ./chat -m ggml-alpaca-13b-q4.bin

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ You can download the weights for `ggml-alpaca-7b-q4.bin` with BitTorrent `magnet
 
 Alternatively you can download them with IPFS.
 
-```
+```sh
 # any of these will work
-curl -o ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
-curl -o ggml-alpaca-7b-q4.bin -C - https://ipfs.io/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
-curl -o ggml-alpaca-7b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
+curl -o ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
+curl -o ggml-alpaca-7b-q4.bin -C - https://ipfs.io/ipfs/QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
+curl -o ggml-alpaca-7b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
+ipfs get QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
 ```
 
 Save the `ggml-alpaca-7b-q4.bin` file in the same directory as your `./chat` executable. 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ wget -c https://cloudflare-ipfs.com/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU
 ipfs get QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
 ```
 
-```
+```sh
 ./chat -m ggml-alpaca-13b-q4.bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Alternatively you can download them with IPFS.
 
 ```sh
 # any of these will work
-curl -o ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
-curl -o ggml-alpaca-7b-q4.bin -C - https://ipfs.io/ipfs/QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
-curl -o ggml-alpaca-7b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
-ipfs get QmR1PH2ZF313jxmK8ZGcG6XBNpvk7geRt3R1oAeTx2u1ks/ggml-alpaca-7b-q4.bin
+curl -o ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-7b-q4.bin
+curl -o ggml-alpaca-7b-q4.bin -C - https://ipfs.io/ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-7b-q4.bin
+curl -o ggml-alpaca-7b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-7b-q4.bin
+ipfs get QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-7b-q4.bin
 ```
 
 Save the `ggml-alpaca-7b-q4.bin` file in the same directory as your `./chat` executable. 
@@ -64,10 +64,10 @@ Torrent: `magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-a
 
 ```sh
 # any of these will work
-curl -o ggml-alpaca-13b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
-curl -o ggml-alpaca-13b-q4.bin -C - https://ipfs.io/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
-curl -o ggml-alpaca-13b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
-ipfs get QmQqMtqc7224HqAsv7t4CybWFHH6bJ2nmqUc8cU4WoD1Df/ggml-alpaca-13b-q4.bin
+curl -o ggml-alpaca-13b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-13b-q4.bin
+curl -o ggml-alpaca-13b-q4.bin -C - https://ipfs.io/ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-13b-q4.bin
+curl -o ggml-alpaca-13b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-13b-q4.bin
+ipfs get QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-13b-q4.bin
 ```
 
 ```sh


### PR DESCRIPTION
- Add IPFS hash for `ggml-alpaca-13b-q4.bin`
- Add filenames to IPFS hashes
- Add `ipfs get` commands for IPFS users
- Put them in the same IPFS folder

Since IPFS hashes have changed, you can verify they represent the same file as before by comparing the new hash with the old one.

**`ggml-alpaca-7b-q4.bin`**

```yaml
ipfs files stat /ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
Size: 4212727017
CumulativeSize: 4213729010
ChildBlocks: 93
Type: file
```

```yaml
ipfs files stat /ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-7b-q4.bin
QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
Size: 4212727017
CumulativeSize: 4213729010
ChildBlocks: 93
Type: file
```

Both match the old `QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC`

**`ggml-alpaca-13b-q4.bin`**

```sh
ipfs add --only-hash ./ggml-alpaca-13b-q4.bin
added Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G ggml-alpaca-13b-q4.bin
 7.58 GiB / 7.58 GiB [=====================================================================] 100.00%
```

```yaml
ipfs files stat /ipfs/QmZciQDVrWa1JdzT7oD3USGbhNKn3QaSND9kC2XTqZnPJ9/ggml-alpaca-13b-q4.bin
Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
Size: 8136637097
CumulativeSize: 8138572387
ChildBlocks: 2
Type: file
```

Both match `Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G`, but this one wasn't provided by you so you might want to double-check it.

* Closes https://github.com/antimatter15/alpaca.cpp/issues/51