### PR TITLE
🙈 Add output `chat` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/chat
+
 *.o
 *.a
 .cache/


### PR DESCRIPTION
When running `make chat`, a new `chat` executable is generated in the repo's root.

Adding it to the `.gitignore` file helps users of this repository to avoid dirtying the repo every time they use it.