### PR TITLE
Do the windows ANSI color fix properly

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -887,11 +887,12 @@ int main(int argc, char ** argv) {
         sigaction(SIGINT, &sigint_action, NULL);
 #elif defined (_WIN32)
         signal(SIGINT, sigint_handler);
-		//Windows console ANSI color fix 
-		HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
-		DWORD mode;
-		GetConsoleMode(hConsole, &mode);
-		SetConsoleMode(hConsole, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+        // Windows console ANSI color fix
+        DWORD mode;
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hConsole && hConsole != INVALID_HANDLE_VALUE && GetConsoleMode(hConsole, &mode))
+            SetConsoleMode(hConsole, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 #endif
 
         fprintf(stderr, "%s: interactive mode on.\n", __func__);

--- a/chat.cpp
+++ b/chat.cpp
@@ -889,7 +889,7 @@ int main(int argc, char ** argv) {
         signal(SIGINT, sigint_handler);
 
         // Windows console ANSI color fix
-        DWORD mode;
+        DWORD mode = 0;
         HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
         if (hConsole && hConsole != INVALID_HANDLE_VALUE && GetConsoleMode(hConsole, &mode))
             SetConsoleMode(hConsole, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);


### PR DESCRIPTION
the wrong way will cause trouble in multitude of scenarios like when stdout is redirected.
