### PR TITLE
Fixes issue of medium to large prompts causing crashing with no errors while using color mode.

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -1041,10 +1041,10 @@ int main(int argc, char ** argv) {
                 bool another_line=true;
                 while (another_line) {
                     fflush(stdout);
-                    char buf[256] = {0};
+                    char buf[16384] = { 0 };
                     int n_read;
-                    if(params.use_color) printf(ANSI_BOLD ANSI_COLOR_GREEN);
-                    if (scanf("%255[^\n]%n%*c", buf, &n_read) <= 0) {
+                    if (params.use_color) printf(ANSI_BOLD ANSI_COLOR_GREEN);
+                    if (scanf("%16383[^\n]%n%*c", buf, &n_read) <= 0) {
                         // presumable empty line, consume the newline
                         if (scanf("%*c") <= 0) { /*ignore*/ }
                         n_read=0;


### PR DESCRIPTION
- This fixes a major application breaking untraceable error (Large prompts crashing with no error output #122)
- Tested and working