### PR TITLE
Fixed 'memleak' detected by cppcheck

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -1,7 +1,5 @@
 #include "ggml.h"
-
 #include "utils.h"
-
 #include <cassert>
 #include <cmath>
 #include <cstdio>
@@ -561,12 +559,18 @@ bool llama_eval(
 
         // reallocate
         buf_size = buf_size_new;
-        buf = realloc(buf, buf_size);
-        if (buf == nullptr) {
-            fprintf(stderr, "%s: failed to allocate %zu bytes\n", __func__, buf_size);
-            return false;
+        
+         void * tmp = realloc(buf, buf_size);
+         if (NULL == tmp)
+        {
+          fprintf(stderr, "%s: failed to allocate %zu bytes\n", __func__, buf_size);
+          return false;
         }
-    }
+         else
+        {
+         buf = tmp;
+        } 
+   }
 
     struct ggml_init_params params = {
         /*.mem_size   =*/ buf_size,


### PR DESCRIPTION
In terms of curiosity run cppcheck on alpaca.cpp and got that message: 

Checking chat.cpp ...
chat.cpp:564:9: error: Common realloc mistake: 'buf' nulled but not freed upon failure [memleakOnRealloc]
        buf = realloc(buf, buf_size);
        ^
Checking chat.cpp: _WIN32...
Checking chat.cpp: _WIN32;__APPLE__;__MACH__;__unix__...
Checking chat.cpp: __APPLE__;__MACH__;__unix__...
Checking chat.cpp: __ARM_NEON...

Nothing serious I guess, but now there's no errors and network builds ok