### PR TITLE
Fix: Add error handling for memory buffer allocation in ggml_init to prevent segmentation fault

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2447,6 +2447,16 @@ struct ggml_context * ggml_init(struct ggml_init_params params) {
         /*.scratch_save     =*/ { 0, 0, NULL, },
     };
 
+    if (ctx->mem_buffer == NULL) {
+        fprintf(stderr, "%s: failed to allocate memory buffer of size %zu\n", __func__, params.mem_size);
+
+        GGML_PRINT_DEBUG("%s: failed to allocate memory buffer\n", __func__);
+
+        ggml_critical_section_end();
+
+        return NULL;
+    }
+
     ggml_assert_aligned(ctx->mem_buffer);
 
     GGML_PRINT_DEBUG("%s: context initialized\n", __func__);


### PR DESCRIPTION
## Problem

When loading a large language model like Alpaca 30B, the `ggml_init` function tries to allocate a significant amount of memory (25.5 GB). Even if the system has sufficient RAM (e.g., 32 GB), the available memory might not be enough due to other processes or system requirements. In the current implementation, we blindly try to allocate the required memory without checking if the `malloc` operation was successful or failed. If the memory allocation fails, it can result in segmentation faults and undefined behavior.

I encountered this issue when trying to load the Alpaca 30B model and experienced a segmentation fault. To address this problem, we should check the return value of `malloc` and handle memory allocation failures properly.

## Changes

- Added a check for memory buffer allocation failure in `ggml_init`.
- If the memory buffer allocation fails, an error message is printed to stderr, and the function returns NULL.
- The critical section is ended before returning NULL to prevent any potential deadlocks.

## Motivation

By checking the return value of `malloc` and not creating the `ggml_context` when memory allocation fails, we can provide better error handling and prevent segmentation faults. This approach will also make it easier for users to identify the cause of the problem when there isn't enough available memory for the required allocation.

## Request for Feedback

I would appreciate feedback on the error handling implementation, the additional context provided, and any suggestions for improvements.