### PR TITLE
Esc as interrupt

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -758,15 +758,12 @@ bool llama_eval(
 
 static bool is_interacting = false;
 
+
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
 void sigint_handler(int signo) {
     printf(ANSI_COLOR_RESET);
     if (signo == SIGINT) {
-        if (!is_interacting) {
-            is_interacting=true;
-        } else {
-            _exit(130);
-        }
+        _exit(130);
     }
 }
 #endif
@@ -923,7 +920,7 @@ int main(int argc, char ** argv) {
     if (params.interactive) {
         fprintf(stderr, "== Running in chat mode. ==\n"
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
-               " - Press Ctrl+C to interject at any time.\n"
+               " - Press ESC to interject at any time.\n"
 #endif
                " - Press Return to return control to LLaMA.\n"
                " - If you want to submit another line, end your input in '\\'.\n");
@@ -947,6 +944,10 @@ int main(int argc, char ** argv) {
     
 
     while (remaining_tokens > 0) {
+        if (GetAsyncKeyState(VK_ESCAPE)){
+            is_interacting = true;
+        }
+
         // predict
         if (embd.size() > 0) {
             const int64_t t_start_us = ggml_time_us();
@@ -1041,10 +1042,10 @@ int main(int argc, char ** argv) {
                 bool another_line=true;
                 while (another_line) {
                     fflush(stdout);
-                    char buf[16384] = {0};
+                    char buf[256] = {0}; //16384 - for extended length
                     int n_read;
                     if(params.use_color) printf(ANSI_BOLD ANSI_COLOR_GREEN);
-                    if (scanf("%16383[^\n]%n%*c", buf, &n_read) <= 0) {
+                    if (scanf("%255[^\n]%n%*c", buf, &n_read) <= 0) { //16383 - for extended length
                         // presumable empty line, consume the newline
                         if (scanf("%*c") <= 0) { /*ignore*/ }
                         n_read=0;

--- a/chat.cpp
+++ b/chat.cpp
@@ -1041,10 +1041,10 @@ int main(int argc, char ** argv) {
                 bool another_line=true;
                 while (another_line) {
                     fflush(stdout);
-                    char buf[256] = {0};
+                    char buf[16384] = {0};
                     int n_read;
                     if(params.use_color) printf(ANSI_BOLD ANSI_COLOR_GREEN);
-                    if (scanf("%255[^\n]%n%*c", buf, &n_read) <= 0) {
+                    if (scanf("%16383[^\n]%n%*c", buf, &n_read) <= 0) {
                         // presumable empty line, consume the newline
                         if (scanf("%*c") <= 0) { /*ignore*/ }
                         n_read=0;


### PR DESCRIPTION
Fixes issue with using CTRL+C to interrupt prediction. The second CTRL+C would always close the application. This fix adds a check for the ESC key and sets the is_interactive variable to true when detected. This will force the program to return to interactive mode after the current prediction.