### PR TITLE
add download option for model weights file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Download the zip file corresponding to your operating system from the [latest re
 
 Download `ggml-alpaca-7b-q4.bin` and place it in the same folder as the `chat` executable in the zip file. There are several options: 
 
+* download [ggml-model-q4_0.bin](https://huggingface.co/Pi3141/alpaca-7B-ggml/blob/main/ggml-model-q4_0.bin) and rename the resulting file to `ggml-alpaca-7b-q4.bin`
+
 Once you've downloaded the model weights and placed them into the same directory as the `chat` or `chat.exe` executable, run:
 
 ```


### PR DESCRIPTION
Installation instructions in "readme.md" lack any options for downloading the model weights. I thought, it might be a good idea to provide a first one as a start...