### PR TITLE
fix: Change clean directive to remove chat executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ utils.o: utils.cpp utils.h
 	$(CXX) $(CXXFLAGS) -c utils.cpp -o utils.o
 
 clean:
-	rm -f *.o main quantize
+	rm -f *.o chat quantize
 
 chat: chat.cpp ggml.o utils.o
 	$(CXX) $(CXXFLAGS) chat.cpp ggml.o utils.o -o chat $(LDFLAGS)


### PR DESCRIPTION
Existing Makefile removed the executable `main` but this does not exist in this project. Removes `chat` instead.