### PR TITLE
doc: Add link to download `ggml-alpaca-7b-qa.bin` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This combines the [LLaMA foundation model](https://github.com/facebookresearch/l
 
 Download the zip file corresponding to your operating system from the [latest release](https://github.com/antimatter15/alpaca.cpp/releases/latest). On Windows, download `alpaca-win.zip`, on Mac (both Intel or ARM) download `alpaca-mac.zip`, and on Linux (x64) download `alpaca-linux.zip`. 
 
-Download `ggml-alpaca-7b-q4.bin` and place it in the same folder as the `chat` executable in the zip file. There are several options: 
+Download [ggml-alpaca-7b-q4.bin](https://huggingface.co/Sosaka/Alpaca-native-4bit-ggml/tree/main) and place it in the same folder as the `chat` executable in the zip file. There are several options: 
 
 Once you've downloaded the model weights and placed them into the same directory as the `chat` or `chat.exe` executable, run:
 


### PR DESCRIPTION
## Summary
This pull request updates the README.md file to add a missing link to download ggml-alpaca-7b-qa.bin file. The link was not present earlier, making it difficult for users to download the file and use it in their projects.

To fix this issue, I have added the link to the file in the appropriate section of the README.md file. Users can now easily access and download the ggml-alpaca-7b-qa.bin file from the link provided.

I have also tested the link to ensure that it works correctly and the file can be downloaded without any issues.

This change will make it easier for users to get started with the project and use the ggml-alpaca-7b-qa.bin file in their applications.

## Related Issue:
N/A