### PR TITLE
Update ggml.h

### DIFF
--- a/ggml.h
+++ b/ggml.h
@@ -177,6 +177,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdbool.h>
 
+#define __USE_POSIX199309 1
 #define GGML_MAX_DIMS     4
 #define GGML_MAX_NODES    4096
 #define GGML_MAX_PARAMS   16


### PR DESCRIPTION
when `__USE_POSIX199309` is defined (as per time.h), then `CLOCK_MONOTONIC` is declared.

solves the error: `CLOCK_MONOTONIC` undeclared, while doing `make chat`