### PR TITLE
fixed response prompt placement for multi line

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -318,7 +318,7 @@ bool llama_model_load(const std::string & fname, llama_model & model, gpt_vocab 
     fin.close();
 
     std::vector<uint8_t> tmp;
-    
+
     for (int i = 0; i < n_parts; ++i) {
         const int part_id = i;
         //const int part_id = n_parts - i - 1;
@@ -823,7 +823,7 @@ int main(int argc, char ** argv) {
     // load the model
     {
         const int64_t t_start_us = ggml_time_us();
-        if (!llama_model_load(params.model, model, vocab, params.n_ctx)) {  
+        if (!llama_model_load(params.model, model, vocab, params.n_ctx)) {
             fprintf(stderr, "%s: failed to load model from '%s'\n", __func__, params.model.c_str());
             return 1;
         }
@@ -944,7 +944,7 @@ int main(int argc, char ** argv) {
         printf(ANSI_COLOR_YELLOW);
     }
 
-    
+
 
     while (remaining_tokens > 0) {
         // predict
@@ -1033,7 +1033,7 @@ int main(int argc, char ** argv) {
                 // embd_inp.erase(embd_inp.begin());
                 input_consumed = embd_inp.size();
                 embd_inp.insert(embd_inp.end(), prompt_inp.begin(), prompt_inp.end());
-                
+
 
                 printf("\n> ");
 
@@ -1063,11 +1063,15 @@ int main(int argc, char ** argv) {
 
                     std::vector<gpt_vocab::id> line_inp = ::llama_tokenize(vocab, buf, false);
                     embd_inp.insert(embd_inp.end(), line_inp.begin(), line_inp.end());
-                    embd_inp.insert(embd_inp.end(), response_inp.begin(), response_inp.end());
+                    // Add response prompt if last line
+                    if (!another_line) {
+                        embd_inp.insert(embd_inp.end(), response_inp.begin(), response_inp.end());
+                    }
 
                     remaining_tokens -= prompt_inp.size() + line_inp.size() + response_inp.size();
 
                     input_noecho = true; // do not echo this again
+
                 }
 
                 is_interacting = false;


### PR DESCRIPTION
Just a tiny bug I stumbled across while doing some unrelated work. 

Current behavior:
alpaca inserts the saved "response" prompt after every written line, regardless of multi line continuation.

Expected behavior:
alpaca inserts the saved "response" prompt once, after the completed prompt, waiting until all multi lines are processed.

Fix:
Check if `another_line` is set before adding the response prompt.

Before:
```
# juliamerz@Julias-MacBook-Pro.local: ~/hack/alpaca.cpp <master ✘ [*]>                                                                                  ()
ζ ./chat                                                                                                                                         [a0c74a7]
main: seed = 1680750684
llama_model_load: loading model from 'ggml-alpaca-7b-q4.bin' - please wait ...
llama_model_load: ggml ctx size = 6065.34 MB
llama_model_load: memory_size =  2048.00 MB, n_mem = 65536
llama_model_load: loading model part 1/1 from 'ggml-alpaca-7b-q4.bin'
llama_model_load: .................................... done
llama_model_load: model size =  4017.27 MB / num tensors = 291

system_info: n_threads = 4 / 16 | AVX = 1 | AVX2 = 1 | AVX512 = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | VSX = 0 |
main: interactive mode on.
sampling parameters: temp = 0.100000, top_k = 40, top_p = 0.950000, repeat_last_n = 64, repeat_penalty = 1.300000


== Running in chat mode. ==
 - Press Ctrl+C to interject at any time.
 - Press Return to return control to LLaMA.
 - If you want to submit another line, end your input in '\'.
     1 -> ''
 13866 -> ' Below'
   338 -> ' is'
   385 -> ' an'
 15278 -> ' instruction'
   393 -> ' that'
 16612 -> ' describes'
   263 -> ' a'
  3414 -> ' task'
 29889 -> '.'
 14350 -> ' Write'
   263 -> ' a'
  2933 -> ' response'
   393 -> ' that'
  8210 -> ' appropriate'
   368 -> 'ly'
  4866 -> ' complete'
 29879 -> 's'
   278 -> ' the'
  2009 -> ' request'
 29889 -> '.'
    13 -> '
'
    13 -> '
'

> testing \
multi line
     1 -> ''
 29937 -> '#'
  2277 -> '##'
  2799 -> ' Inst'
  4080 -> 'ruction'
 29901 -> ':'
    13 -> '
'
    13 -> '
'
 13424 -> 'testing'
 29871 -> ' '
    13 -> '
'
 29937 -> '#'
  2277 -> '##'
 13291 -> ' Response'
 29901 -> ':'
    13 -> '
'
    13 -> '
'
  9910 -> 'multi'
  1196 -> ' line'
    13 -> '
'
 29937 -> '#'
  2277 -> '##'
 13291 -> ' Response'
 29901 -> ':'
    13 -> '
'
    13 -> '
'
```

After:
```
== Running in chat mode. ==
 - Press Ctrl+C to interject at any time.
 - Press Return to return control to LLaMA.
 - If you want to submit another line, end your input in '\'.
     1 -> ''
 13866 -> ' Below'
   338 -> ' is'
   385 -> ' an'
 15278 -> ' instruction'
   393 -> ' that'
 16612 -> ' describes'
   263 -> ' a'
  3414 -> ' task'
 29889 -> '.'
 14350 -> ' Write'
   263 -> ' a'
  2933 -> ' response'
   393 -> ' that'
  8210 -> ' appropriate'
   368 -> 'ly'
  4866 -> ' complete'
 29879 -> 's'
   278 -> ' the'
  2009 -> ' request'
 29889 -> '.'
    13 -> '
'
    13 -> '
'

> testing \
multi line
     1 -> ''
 29937 -> '#'
  2277 -> '##'
  2799 -> ' Inst'
  4080 -> 'ruction'
 29901 -> ':'
    13 -> '
'
    13 -> '
'
 13424 -> 'testing'
 29871 -> ' '
    13 -> '
'
  9910 -> 'multi'
  1196 -> ' line'
    13 -> '
'
 29937 -> '#'
  2277 -> '##'
 13291 -> ' Response'
 29901 -> ':'
    13 -> '
'
    13 -> '
'
This test case will demonstrate how to use multiple lines of text in a single cell using Markdown. The^C
>
